### PR TITLE
Update ffbonded.itp

### DIFF
--- a/amber14sb_parmbsc1_cufix.ff/ffbonded.itp
+++ b/amber14sb_parmbsc1_cufix.ff/ffbonded.itp
@@ -780,6 +780,7 @@ CS  N2  CA  NC       4      180.00     4.60240     2
 CT  CV  CC  NA       4      180.00     4.60240     2
 CT  CW  CC  NA       4      180.00     4.60240     2
 NA  CW  CC  CT       4      180.00     4.60240     2
+NA  CV  CC  CT       4      180.00     4.60240     2     ;;; HID force field added
 NB  CW  CC  CT       4      180.00     4.60240     2    
 CT  CW  CC  NB       4      180.00     4.60240     2
 CT  O   C   OH       4      180.00    43.93200     2


### PR DESCRIPTION
When running the gmx grompp command, an error occurs: No default Improper Dih. types. PDB structure ID: 5Y36.

By adding a line to line 783 of the ffbonded.itp file, the problem disappears. The same correction was made in the ffbonded.itp file of the amber14sb_parmbsc1 force field. 